### PR TITLE
Make HTTP client configurable via YAML properties

### DIFF
--- a/src/main/java/com/czertainly/csc/configuration/HttpClientProperties.java
+++ b/src/main/java/com/czertainly/csc/configuration/HttpClientProperties.java
@@ -1,0 +1,87 @@
+package com.czertainly.csc.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for HTTP client connection pool and timeouts.
+ */
+@Component
+@ConfigurationProperties(prefix = "http.client")
+public class HttpClientProperties {
+
+    /**
+     * Maximum total connections in the connection pool.
+     * Default: 200
+     */
+    private int maxTotal = 200;
+
+    /**
+     * Maximum connections per route.
+     * Default: 20
+     */
+    private int defaultMaxPerRoute = 20;
+
+    /**
+     * Connection timeout in seconds.
+     * Time to wait for a connection from the connection pool.
+     * Default: 10 seconds
+     */
+    private int connectionTimeoutSeconds = 10;
+
+    /**
+     * Socket read timeout in seconds.
+     * Time to wait for data after establishing connection.
+     * Default: 30 seconds
+     */
+    private int readTimeoutSeconds = 30;
+
+    /**
+     * HTTP Response timeout in seconds.
+     * Total time to wait for the complete response.
+     * Default: 30 seconds
+     */
+    private int responseTimeoutSeconds = 30;
+
+    public int getMaxTotal() {
+        return maxTotal;
+    }
+
+    public void setMaxTotal(int maxTotal) {
+        this.maxTotal = maxTotal;
+    }
+
+    public int getDefaultMaxPerRoute() {
+        return defaultMaxPerRoute;
+    }
+
+    public void setDefaultMaxPerRoute(int defaultMaxPerRoute) {
+        this.defaultMaxPerRoute = defaultMaxPerRoute;
+    }
+
+    public int getConnectionTimeoutSeconds() {
+        return connectionTimeoutSeconds;
+    }
+
+    public void setConnectionTimeoutSeconds(int connectionTimeoutSeconds) {
+        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+    }
+
+    public int getReadTimeoutSeconds() {
+        return readTimeoutSeconds;
+    }
+
+    public void setReadTimeoutSeconds(int readTimeoutSeconds) {
+        this.readTimeoutSeconds = readTimeoutSeconds;
+    }
+
+    public int getResponseTimeoutSeconds()
+    {
+        return responseTimeoutSeconds;
+    }
+
+    public void setResponseTimeoutSeconds(int responseTimeoutSeconds)
+    {
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
+    }
+}

--- a/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
+++ b/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
@@ -10,6 +10,7 @@ import com.czertainly.csc.signing.configuration.WorkerRepository;
 import com.czertainly.csc.signing.configuration.WorkerWithCapabilities;
 import com.czertainly.csc.signing.configuration.loader.WorkerConfigurationLoader;
 import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -19,6 +20,7 @@ import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ssl.SslBundle;
@@ -51,6 +53,12 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @EnableMethodSecurity
 @PropertySource(value = "file:${csc.profilesConfigurationDirectory}/key-pool-profiles.yml", factory = MultipleYamlPropertySourceFactory.class)
 public class ServerConfiguration {
+
+    private final HttpClientProperties httpClientProperties;
+
+    public ServerConfiguration(HttpClientProperties httpClientProperties) {
+        this.httpClientProperties = httpClientProperties;
+    }
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -127,7 +135,7 @@ public class ServerConfiguration {
 
             SSLContext sslContext = builder.build();
 
-            final HttpClient httpClient = getHttpClient(sslContext, null);
+            final HttpClient httpClient = getHttpClient(sslContext, null, httpClientProperties);
 
             return new HttpComponentsClientHttpRequestFactory(httpClient);
         } catch (Exception e) {
@@ -159,7 +167,7 @@ public class ServerConfiguration {
 
             SSLContext sslContext = builder.build();
 
-            final HttpClient httpClient = getHttpClient(sslContext, null);
+            final HttpClient httpClient = getHttpClient(sslContext, null, httpClientProperties);
 
             return new HttpComponentsClientHttpRequestFactory(httpClient);
         } catch (Exception e) {
@@ -223,7 +231,7 @@ public class ServerConfiguration {
 
             SSLContext sslContext = builder.build();
 
-           final HttpClient httpClient = getHttpClient(sslContext, new HttpComponents5ClientFactory.RemoveSoapHeadersInterceptor());
+           final HttpClient httpClient = getHttpClient(sslContext, new HttpComponents5ClientFactory.RemoveSoapHeadersInterceptor(), httpClientProperties);
 
             return new SimpleHttpComponents5MessageSender(httpClient);
         } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException | KeyManagementException e) {
@@ -231,15 +239,26 @@ public class ServerConfiguration {
         }
     }
 
-    private static HttpClient getHttpClient(SSLContext sslContext, HttpRequestInterceptor interceptor) {
+    private static HttpClient getHttpClient(SSLContext sslContext, HttpRequestInterceptor interceptor, HttpClientProperties properties) {
         TlsSocketStrategy tlsSocketStrategy = new DefaultClientTlsStrategy(sslContext);
-        SocketConfig socketConfig = SocketConfig.custom().setSoTimeout(10, TimeUnit.SECONDS).build();
+        SocketConfig socketConfig = SocketConfig.custom()
+                .setSoTimeout(properties.getReadTimeoutSeconds(), TimeUnit.SECONDS)
+                .build();
         final var connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
                                                                                .setDefaultSocketConfig(socketConfig)
                                                                                .setTlsSocketStrategy(tlsSocketStrategy)
+                                                                               .setMaxConnTotal(properties.getMaxTotal())
+                                                                               .setMaxConnPerRoute(properties.getDefaultMaxPerRoute())
                                                                                .build();
 
-        HttpClientBuilder builder = HttpClients.custom().setConnectionManager(connectionManager);
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectionRequestTimeout(Timeout.ofSeconds(properties.getConnectionTimeoutSeconds()))
+                .setResponseTimeout(Timeout.ofSeconds(properties.getResponseTimeoutSeconds()))
+                .build();
+
+        HttpClientBuilder builder = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig);
 
         if (interceptor != null) {
             builder.addRequestInterceptorFirst(interceptor);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,31 @@ csc:
         # The value must be greater than 0, default is 10
         maxKeyDeletion: 10
 
+# HTTP client configuration for all outbound connections (SignServer, EJBCA, IDP)
+http:
+    client:
+        # Maximum total connections in the connection pool
+        # Increase this if you have high concurrent requests to external services
+        # Default: 200
+        maxTotal: 200
+        # Maximum connections per route (per host/port combination)
+        # This limits connections to a single endpoint
+        # Default: 20
+        defaultMaxPerRoute: 20
+        # Connection timeout in seconds
+        # Time to wait for a connection from the connection pool
+        # Default: 10
+        connectionTimeoutSeconds: 10
+        # Socket read timeout in seconds
+        # Time to wait for data after establishing connection
+        # Increase this if external services are slow to respond
+        # Default: 30
+        readTimeoutSeconds: 30
+        # HTTP response timeout in seconds
+        # Total time to wait for the complete response.
+        # Default: 30
+        responseTimeoutSeconds: 30
+
 # IDP configuration
 idp:
     # Base URL of the IDP OpenID Connect endpoint


### PR DESCRIPTION
Added configurable HTTP client connection pool and timeout settings:

New HttpClientProperties configuration class with the following parameters:
- maxTotal: Maximum total connections in the pool (default: 200)
- defaultMaxPerRoute: Maximum connections per route (default: 20)
- connectionTimeoutSeconds: Connection request timeout (default: 10s)
- readTimeoutSeconds: Socket read timeout (default: 30s)

Updated ServerConfiguration to:
- Inject and use HttpClientProperties
- Apply connection pool settings (setMaxConnTotal, setMaxConnPerRoute)
- Apply timeout settings via RequestConfig (setConnectionRequestTimeout, setSoTimeout)
- All HTTP clients (SignServer, EJBCA, IDP) now use these settings

Configuration can be customized in application.yml under http.client section. This allows tuning connection pooling and timeouts for high-concurrency scenarios without code changes.